### PR TITLE
fixed method overwrite of `log1p`

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -59,11 +59,11 @@
 if VERSION < v"0.7-"
     @define_diffrule Base.gamma(x)            = :(  digamma($x) * gamma($x)            )
     @define_diffrule Base.lgamma(x)           = :(  digamma($x)                        )
+    @define_diffrule Base.Math.JuliaLibm.log1p(x) = :(  inv($x + 1)                    )
 else
     @define_diffrule SpecialFunctions.gamma(x) = :(  digamma($x) * gamma($x)           )
     @define_diffrule SpecialFunctions.lgamma(x) = :(  digamma($x)                      )
 end
-@define_diffrule Base.Math.JuliaLibm.log1p(x) = :(  inv($x + 1)                        )
 @define_diffrule Base.transpose(x)            = :(  1                                  )
 @define_diffrule Base.abs(x)                  = :( signbit($x) ? -one($x) : one($x)    )
 


### PR DESCRIPTION
This is a possible fix for #14.

I don't know if the version being used here is correct.  I *do* know that on the first 0.7 release candidate, making this definition was giving a method overwrite error.  I'd be happy to change if anyone knows what the proper condition for this definition is, or where I might be able to find that.