### PR TITLE
Fix interpolation

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -109,9 +109,9 @@ end
     :( -(sqrt(π) / 2) * exp(SpecialFunctions.erfcinv($x)^2)  )
 @define_diffrule SpecialFunctions.erfi(x)        = :(  (2 / sqrt(π)) * exp($x * $x)        )
 @define_diffrule SpecialFunctions.erfcx(x)       =
-    :(  (2 * x * SpecialFunctions.erfcx($x)) - (2 / sqrt(π))  )
+    :(  (2 * $x * SpecialFunctions.erfcx($x)) - (2 / sqrt(π))  )
 @define_diffrule SpecialFunctions.dawson(x)      =
-    :(  1 - (2 * x * SpecialFunctions.dawson($x))  )
+    :(  1 - (2 * $x * SpecialFunctions.dawson($x))  )
 @define_diffrule SpecialFunctions.digamma(x) =
     :(  SpecialFunctions.trigamma($x)  )
 @define_diffrule SpecialFunctions.invdigamma(x)  =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,14 @@
-using Base.Test
-using SpecialFunctions, NaNMath
+if VERSION < v"0.7-"
+    using Base.Test
+    srand(1)
+else
+    using Test
+    import Random
+    Random.seed!(1)
+end
+import SpecialFunctions, NaNMath
 using DiffRules
 
-srand(1)
 
 function finitediff(f, x)
     ϵ = cbrt(eps(typeof(x))) * max(one(typeof(x)), abs(x))
@@ -16,23 +22,23 @@ for (M, f, arity) in DiffRules.diffrules()
     (M, f, arity) ∈ non_numeric_arg_functions && continue
     if arity == 1
         @test DiffRules.hasdiffrule(M, f, 1)
-        deriv = DiffRules.diffrule(M, f, :x)
+        deriv = DiffRules.diffrule(M, f, :goo)
         modifier = in(f, (:asec, :acsc, :asecd, :acscd, :acosh, :acoth)) ? 1 : 0
         @eval begin
-            x = rand() + $modifier
-            @test isapprox($deriv, finitediff($M.$f, x), rtol=0.05)
+            goo = rand() + $modifier
+            @test isapprox($deriv, finitediff($M.$f, goo), rtol=0.05)
         end
     elseif arity == 2
         @test DiffRules.hasdiffrule(M, f, 2)
-        derivs = DiffRules.diffrule(M, f, :x, :y)
+        derivs = DiffRules.diffrule(M, f, :foo, :bar)
         @eval begin
-            x, y = rand(1:10), rand()
+            foo, bar = rand(1:10), rand()
             dx, dy = $(derivs[1]), $(derivs[2])
             if !(isnan(dx))
-                @test isapprox(dx, finitediff(z -> $M.$f(z, y), float(x)), rtol=0.05)
+                @test isapprox(dx, finitediff(z -> $M.$f(z, bar), float(foo)), rtol=0.05)
             end
             if !(isnan(dy))
-                @test isapprox(dy, finitediff(z -> $M.$f(x, z), y), rtol=0.05)
+                @test isapprox(dy, finitediff(z -> $M.$f(foo, z), bar), rtol=0.05)
             end
         end
     end


### PR DESCRIPTION
A couple of symbols weren't interpolated properly in a couple of the definitions. This fixes them and changes the unit testing slightly to use less-likely-to-be-chosen symbols for variable names.