### PR TITLE
add hook for abs definition that downstream packages can overload

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -70,7 +70,11 @@ else
         :(  SpecialFunctions.digamma($x)  )
 end
 @define_diffrule Base.transpose(x)            = :(  1                                  )
-@define_diffrule Base.abs(x)                  = :( signbit($x) ? -one($x) : one($x)    )
+@define_diffrule Base.abs(x)                  = :( DiffRules._abs_deriv($x)            )
+
+# We provide this hook for special number types like `Interval`
+# that need their own special definition of `abs`.
+_abs_deriv(x) = signbit(x) ? -one(x) : one(x)
 
 # binary #
 #--------#


### PR DESCRIPTION
This is the kind of hack that is obsoleted by ChainRules' method overloading approach vs a symbolic table, but in the meantime, this will enable @dpsanders to define an `abs` derivative for Intervals