### PR TITLE
Add missing rule for Base.mod2pi(x)

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -59,6 +59,7 @@
 @define_diffrule Base.acoth(x)                = :(  inv(1 - $x^2)                      )
 @define_diffrule Base.deg2rad(x)              = :(  π / 180                            )
 @define_diffrule Base.rad2deg(x)              = :(  180 / π                            )
+@define_diffrule Base.mod2pi(x)               = :(  1                                  )
 if VERSION < v"0.7-"
     @define_diffrule Base.gamma(x)            = :(  digamma($x) * gamma($x)            )
     @define_diffrule Base.lgamma(x)           = :(  digamma($x)                        )


### PR DESCRIPTION
Fix issue #118 from Zygote. It seems to be better adding the rule here instead of the end library.

https://github.com/FluxML/Zygote.jl/issues/118