### PR TITLE
Upgrade to SpecialFunctions 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 NaNMath = "0.3"
-SpecialFunctions = "0.7"
+SpecialFunctions = "0.8"
 julia = "1"
 
 [extras]

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -59,16 +59,10 @@
 @define_diffrule Base.acoth(x)                = :(  inv(1 - $x^2)                      )
 @define_diffrule Base.deg2rad(x)              = :(  π / 180                            )
 @define_diffrule Base.rad2deg(x)              = :(  180 / π                            )
-if VERSION < v"0.7-"
-    @define_diffrule Base.gamma(x)            = :(  digamma($x) * gamma($x)            )
-    @define_diffrule Base.lgamma(x)           = :(  digamma($x)                        )
-    @define_diffrule Base.Math.JuliaLibm.log1p(x) = :(  inv($x + 1)                    )
-else
-    @define_diffrule SpecialFunctions.gamma(x) =
-        :(  SpecialFunctions.digamma($x) * SpecialFunctions.gamma($x)  )
-    @define_diffrule SpecialFunctions.lgamma(x) =
-        :(  SpecialFunctions.digamma($x)  )
-end
+@define_diffrule SpecialFunctions.gamma(x) =
+    :(  SpecialFunctions.digamma($x) * SpecialFunctions.gamma($x)  )
+@define_diffrule SpecialFunctions.loggamma(x) =
+    :(  SpecialFunctions.digamma($x)  )
 @define_diffrule Base.transpose(x)            = :(  1                                  )
 @define_diffrule Base.abs(x)                  = :( DiffRules._abs_deriv($x)            )
 
@@ -167,7 +161,7 @@ end
     :NaN, :(  SpecialFunctions.polygamma($m + 1, $x)  )
 @define_diffrule SpecialFunctions.beta(a, b)      =
     :( SpecialFunctions.beta($a, $b)*(SpecialFunctions.digamma($a) - SpecialFunctions.digamma($a + $b)) ), :(  SpecialFunctions.beta($a, $b)*(SpecialFunctions.digamma($b) - SpecialFunctions.digamma($a + $b))     )
-@define_diffrule SpecialFunctions.lbeta(a, b)     =
+@define_diffrule SpecialFunctions.logbeta(a, b)     =
     :( SpecialFunctions.digamma($a) - SpecialFunctions.digamma($a + $b)  ), :(  SpecialFunctions.digamma($b) - SpecialFunctions.digamma($a + $b)  )
 
 # TODO:


### PR DESCRIPTION
In version 0.8 of `SpecialFunctions` `lgamma` was split into `loggamma` and `logabsgamma` where the latter returns a tuple of the value and the sign. Similarly changes were made for `lbeta`. The old `lgamma` and `lbeta` used to return just the log of the absolute value of the argument which often was forgotten. That was also the case for the definitions here in `DiffRules` but luckily that means that the definitions become correct when we change `lgamma` to `loggamma` and `lbeta` to `logbeta` as this PR does. I plan to release version 0.1 once this PR has been merged since there are downstream packages waiting for this.