### PR TITLE
Avoid inv() in / and \

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -74,11 +74,11 @@ _abs_deriv(x) = signbit(x) ? -one(x) : one(x)
 # binary #
 #--------#
 
-@define_diffrule Base.:+(x, y) = :( 1                  ), :(  1                 )
-@define_diffrule Base.:-(x, y) = :( 1                  ), :( -1                 )
+@define_diffrule Base.:+(x, y) = :( one($x)            ), :(  one($y)           )
+@define_diffrule Base.:-(x, y) = :( one($x)            ), :( -one($y)           )
 @define_diffrule Base.:*(x, y) = :( $y                 ), :(  $x                )
-@define_diffrule Base.:/(x, y) = :( inv($y)            ), :( -($x / $y / $y)    )
-@define_diffrule Base.:\(x, y) = :( -($y / $x / $x)    ), :( inv($x)            )
+@define_diffrule Base.:/(x, y) = :( one($x) / $y       ), :( -($x / $y / $y)    )
+@define_diffrule Base.:\(x, y) = :( -($y / $x / $x)    ), :( one($y) / ($x)     )
 @define_diffrule Base.:^(x, y) = :( $y * ($x^($y - 1)) ), :(  ($x^$y) * log($x) )
 
 if VERSION < v"0.7-"


### PR DESCRIPTION
This solves a common issue where taking the derivative of f(x::Float32, y::Int) = x / y with respect to x accidentally promotes the number type from Float32 to Float64.

This issue is rather unexpected and hard to discover in Flux.

Ref:

- https://github.com/FluxML/Flux.jl/issues/815
- https://github.com/FluxML/Flux.jl/issues/1026
- https://github.com/JuliaDiff/DiffRules.jl/issues/26