### PR TITLE
Comment out trinary rules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffRules"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -104,10 +104,14 @@ end
 # trinary #
 #---------#
 
+#=
+
 @define_diffrule Base.muladd(x, y, z) = :($y), :($x), :(one($z))
 @define_diffrule Base.fma(x, y, z)    = :($y), :($x), :(one($z))
 
 @define_diffrule Base.ifelse(p, x, y) = false, :($p), :(!$p)
+
+=#
 
 ####################
 # SpecialFunctions #

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ for (M, f, arity) in DiffRules.diffrules()
             end
         end
     elseif arity == 3
+        #=
         @test DiffRules.hasdiffrule(M, f, 3)
         derivs = DiffRules.diffrule(M, f, :foo, :bar, :goo)
         @eval begin
@@ -62,6 +63,7 @@ for (M, f, arity) in DiffRules.diffrules()
                 @test isapprox(dz, finitediff(z -> $M.$f(foo, bar, z), goo), rtol=0.05)
             end
         end
+        =#
     end
 end
 
@@ -80,6 +82,7 @@ for xtype in [:Float64, :BigFloat, :Int64]
 end
 
 # Test ifelse separately as first argument is boolean
+#=
 @test DiffRules.hasdiffrule(:Base, :ifelse, 3)
 derivs = DiffRules.diffrule(:Base, :ifelse, :foo, :bar, :goo)
 for cond in [true, false]
@@ -91,4 +94,4 @@ for cond in [true, false]
         @test isapprox(dz, finitediff(z -> ifelse(foo, bar, z), goo), rtol=0.05)
     end
 end
-
+=#


### PR DESCRIPTION
This removes the 3-argument rules introduced in https://github.com/JuliaDiff/DiffRules.jl/pull/54

While they appear to be explicitly supported by this package, they are violently rejected by ForwardDiff, it turns out. 

According to https://github.com/SciML/ColPrac#accidental-breaking-releases the right path is to immediately tag a patch version without the problematic changes.