### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -19,8 +19,11 @@ jobs:
         package:
           - {user: JuliaDiff, repo: ForwardDiff.jl, group: All}
           - {user: FluxML, repo: Tracker.jl, group: All}
+          - {user: FluxML, repo: Zygote.jl, group: All}
+          - {user: invenia, repo: Nabla.jl, group: All}
           - {user: JuliaSymbolics, repo: Symbolics.jl, group: All}
           - {user: SciML, repo: ModelingToolkit.jl, group: All}
+          - {user: PSORLab, repo: EAGO.jl, group: All}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,50 @@
+name: IntegrationTest
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    runs-on: ${{ matrix.os }}
+    env:
+      GROUP: ${{ matrix.package.group }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+        package:
+          - {user: JuliaDiff, repo: ForwardDiff.jl, group: All}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine
+            # It means we marked this as a breaking change, so we don't need to worry about
+            # Mistakenly introducing a breaking change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -18,6 +18,9 @@ jobs:
         os: [ubuntu-latest]
         package:
           - {user: JuliaDiff, repo: ForwardDiff.jl, group: All}
+          - {user: FluxML, repo: Tracker.jl, group: All}
+          - {user: JuliaSymbolics, repo: Symbolics.jl, group: All}
+          - {user: SciML, repo: ModelingToolkit.jl, group: All}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This should add a CI run which tests ForwardDiff. Based on https://github.com/SciML/DiffEqBase.jl/blob/master/.github/workflows/Downstream.yml

Possibly other packages should be included. There's a list here: https://juliahub.com/ui/Packages/DiffRules/x2ZNk/1.2.1?t=2

I added a few. If I couldn't find the tests, or the took over an hour to run, or they seemed to be failing already, then I skipped the package. (Nabla somehow got in despite failing here: https://github.com/invenia/Nabla.jl/runs/2981519710?check_suite_focus=true, same message a few days ago so not caused by latest DiffRules PRs.)