### PR TITLE
remove rule for identity

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -67,7 +67,6 @@
 @define_diffrule SpecialFunctions.loggamma(x) =
     :(  SpecialFunctions.digamma($x)  )
 
-@define_diffrule Base.identity(x)             = :(  1                                  )
 @define_diffrule Base.conj(x)                 = :(  1                                  )
 @define_diffrule Base.adjoint(x)              = :(  1                                  )
 @define_diffrule Base.transpose(x)            = :(  1                                  )


### PR DESCRIPTION
This one causes quite a lot of invalidations (https://github.com/SciML/DiffEqBase.jl/pull/698#issuecomment-896872594). It was added in https://github.com/JuliaDiff/DiffRules.jl/pull/54 but it is unclear why it was added.

Is it needed for anything?