### PR TITLE
Remove rules for `conj`, `adjoint`, and `transpose`

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -18,6 +18,7 @@ jobs:
         os: [ubuntu-latest]
         package:
           - {user: JuliaDiff, repo: ForwardDiff.jl, group: All}
+          - {user: JuliaDiff, repo: ReverseDiff.jl, group: All}
           - {user: FluxML, repo: Tracker.jl, group: All}
           - {user: FluxML, repo: Zygote.jl, group: All}
           - {user: invenia, repo: Nabla.jl, group: All}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffRules"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -67,9 +67,6 @@
 @define_diffrule SpecialFunctions.loggamma(x) =
     :(  SpecialFunctions.digamma($x)  )
 
-@define_diffrule Base.conj(x)                 = :(  1                                  )
-@define_diffrule Base.adjoint(x)              = :(  1                                  )
-@define_diffrule Base.transpose(x)            = :(  1                                  )
 @define_diffrule Base.abs(x)                  = :( DiffRules._abs_deriv($x)            )
 
 # We provide this hook for special number types like `Interval`


### PR DESCRIPTION
This PR removes the rules for `conj`, `adjoint`, and `transpose` since they cause problems with ReverseDiff (https://github.com/JuliaDiff/DiffRules.jl/pull/54 broke some tests for `adjoint`; see https://github.com/JuliaDiff/ReverseDiff.jl/issues/183#issuecomment-921287528 and the other comments there for details) and the default fallbacks in https://github.com/JuliaLang/julia/blob/c5f348726cebbe55e169d4d62225c2b1e587f497/base/number.jl#L211-L213 should be sufficient (similar to the discussion about `identity` in https://github.com/JuliaDiff/DiffRules.jl/pull/64).

I checked locally that the ReverseDiff issues are fixed by this PR.

**Edit**: I also added ReverseDiff to the integration tests.