### PR TITLE
Fix doctest failure

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -139,8 +139,14 @@ To include all rules, specify `filter_modules = nothing`.
 # Examples
 
 ```jldoctest
-julia> DiffRules.diffrules() |> collect |> sort |> first
-(:Base, :*, 2)
+julia> first(DiffRules.diffrules()) isa Tuple{Symbol,Symbol,Int}
+true
+
+julia> (:Base, :log, 1) in DiffRules.diffrules()
+true
+
+julia> (:Base, :*, 2) in DiffRules.diffrules()
+true
 ```
 
 If you call `diffrules()`, only rules for Base, SpecialFunctions, and

--- a/src/api.jl
+++ b/src/api.jl
@@ -139,8 +139,8 @@ To include all rules, specify `filter_modules = nothing`.
 # Examples
 
 ```jldoctest
-julia> first(DiffRules.diffrules())
-(:Base, :log2, 1)
+julia> DiffRules.diffrules() |> collect |> sort |> first
+(:Base, :*, 2)
 ```
 
 If you call `diffrules()`, only rules for Base, SpecialFunctions, and


### PR DESCRIPTION
The order in which DiffRules.diffrules() outputs things is not deterministic (because it depends on the order in which `keys(..)` returns things).

This means this jldoctest can fail:

```julia
julia> first(DiffRules.diffrules())
(:Base, :log2, 1)
```

Here we make it so that the output is deterministic.