### PR TITLE
Revert to zero dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffRules"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-LogExpFunctions = "0.3"
+LogExpFunctions = "0.3.2"
 NaNMath = "0.3"
 SpecialFunctions = "0.8, 0.9, 0.10, 1.0, 2"
 julia = "1"

--- a/src/DiffRules.jl
+++ b/src/DiffRules.jl
@@ -2,8 +2,6 @@ __precompile__()
 
 module DiffRules
 
-import LogExpFunctions
-
 include("api.jl")
 include("rules.jl")
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -255,5 +255,4 @@ end
     :(z = LogExpFunctions.logsubexp($x, $y); $x > $y ? exp($x - z) : -exp($x - z)),
     :(z = LogExpFunctions.logsubexp($x, $y); $x > $y ? -exp($y - z) : exp($y - z))
 
-# only defined in LogExpFunctions >= 0.3.2
 @define_diffrule LogExpFunctions.xlog1py(x, y) = :(log1p($y)), :($x / (1 + $y))

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -256,6 +256,4 @@ end
     :(z = LogExpFunctions.logsubexp($x, $y); $x > $y ? -exp($y - z) : exp($y - z))
 
 # only defined in LogExpFunctions >= 0.3.2
-if isdefined(LogExpFunctions, :xlog1py)
-    @define_diffrule LogExpFunctions.xlog1py(x, y) = :(log1p($y)), :($x / (1 + $y))
-end
+@define_diffrule LogExpFunctions.xlog1py(x, y) = :(log1p($y)), :($x / (1 + $y))


### PR DESCRIPTION
Until recently this package had no dependencies at all. It defines rules for SpecialFunctions and bounds the version needed, but does not load the package. I see no reason that the same mechanism can't be used for LogExpFunctions.

I didn't notice this in #69, and I see no discussion of this change there, everyone was focused on other issues. I think that moving away from zero deps is something that we need a positive reason to do. Until we have one, keeping the old behaviour seems preferable. 

Test failures for 1.7 aren't new, or are new only in that 1.7 is the new 1, not caused by this PR:
```
100
check rules: Test Failed at /home/runner/work/DiffRules.jl/DiffRules.jl/test/runtests.jl:54
101
  Expression: isapprox(dy, finitediff((z->begin
102
                Base.mod(foo, z)
103
            end), bar), rtol = 0.05)
104
   Evaluated: isapprox(-4.0, 33023.599675503; rtol = 0.05)
105
Stacktrace:
```