### PR TITLE
fix mod CI test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ end
 @testset "DiffRules" begin
 @testset "check rules" begin
 
-non_numeric_arg_functions = [(:Base, :rem2pi, 2), (:Base, :ifelse, 3)]
+non_numeric_arg_functions = [(:Base, :rem2pi, 2), (:Base, :ifelse, 3), (:Base, :mod, 2)]
 
 for (M, f, arity) in DiffRules.diffrules(; filter_modules=nothing)
     (M, f, arity) ∈ non_numeric_arg_functions && continue
@@ -89,6 +89,18 @@ for xtype in [:Float64, :BigFloat, :Int64]
                 @test isnan(dy)
             end
         end
+    end
+end
+
+# Treat mod separately because of discontinuities at integers
+derivs = DiffRules.diffrule(:Base, :mod, :x, :y)
+@eval begin
+    let
+        x = randn()
+        y = randn()
+        dx, dy = $(derivs[1]), $(derivs[2])
+        @test isapprox(dx, finitediff(z -> mod(z, y), float(x)), rtol=0.05)
+        @test isapprox(dy, finitediff(z -> mod(x, z), float(y)), rtol=0.05)
     end
 end
 end


### PR DESCRIPTION
CI is failing on Julia v1.7. 

The failure is ocurring when testing the rule for `Base.mod`. This function is discontinuous at integer values, so actually I don't understand why tests were passing in previous versions of Julia. In Julia v1.7 the random stream changed and it could be that the issue was just by chance not erroring before, but now it is.

So here I just test `mod` separately, on non-integer arguments.
