### PR TITLE
Add missing rules for SpecialFunctions 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,9 @@ SpecialFunctions = "0.10, 1.0, 2"
 julia = "1.3"
 
 [extras]
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["FiniteDifferences", "Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffRules"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.9.0"
+version = "1.10.0"
 
 [deps]
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -189,6 +189,9 @@ _abs_deriv(x) = signbit(x) ? -one(x) : one(x)
 # binary #
 #--------#
 
+@define_diffrule SpecialFunctions.erf(x, y) =
+    :(  -2 / sqrt(π) * exp(-x^2)  ), :(  2 / sqrt(π) * exp(-y^2)  )
+
 # derivatives with respect to the order `ν` exist but are not implemented
 # (analogously to the ChainRules definitions in SpecialFunctions)
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -190,7 +190,7 @@ _abs_deriv(x) = signbit(x) ? -one(x) : one(x)
 #--------#
 
 @define_diffrule SpecialFunctions.erf(x, y) =
-    :(  -2 / sqrt(π) * exp(-x^2)  ), :(  2 / sqrt(π) * exp(-y^2)  )
+    :(  -2 / sqrt(π) * exp(-$x^2)  ), :(  2 / sqrt(π) * exp(-$y^2)  )
 
 # derivatives with respect to the order `ν` exist but are not implemented
 # (analogously to the ChainRules definitions in SpecialFunctions)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -117,6 +117,8 @@ _abs_deriv(x) = signbit(x) ? -one(x) : one(x)
 @define_diffrule SpecialFunctions.erfinv(x)      =
     :(  (sqrt(π) / 2) * exp(SpecialFunctions.erfinv($x)^2)  )
 @define_diffrule SpecialFunctions.erfc(x)        = :( -(2 / sqrt(π)) * exp(-$x * $x)       )
+@define_diffrule SpecialFunctions.logerfc(x)     =
+    :( -(2 * exp(- $x^2 - SpecialFunctions.logerfc($x))) / sqrt(π) )
 @define_diffrule SpecialFunctions.erfcinv(x)     =
     :( -(sqrt(π) / 2) * exp(SpecialFunctions.erfcinv($x)^2)  )
 @define_diffrule SpecialFunctions.erfi(x)        = :(  (2 / sqrt(π)) * exp($x * $x)        )
@@ -124,6 +126,7 @@ _abs_deriv(x) = signbit(x) ? -one(x) : one(x)
     :(  (2 * $x * SpecialFunctions.erfcx($x)) - (2 / sqrt(π))  )
 @define_diffrule SpecialFunctions.logerfcx(x) =
     :(  2 * ($x - inv(SpecialFunctions.erfcx($x) * sqrt(π)))  )
+
 @define_diffrule SpecialFunctions.dawson(x)      =
     :(  1 - (2 * $x * SpecialFunctions.dawson($x))  )
 @define_diffrule SpecialFunctions.digamma(x) =
@@ -132,14 +135,35 @@ _abs_deriv(x) = signbit(x) ? -one(x) : one(x)
     :(  inv(SpecialFunctions.trigamma(SpecialFunctions.invdigamma($x)))  )
 @define_diffrule SpecialFunctions.trigamma(x)    =
     :(  SpecialFunctions.polygamma(2, $x)  )
+
+# derivatives for `airybix` and `airybiprimex` are only correct for real inputs
+# `airyaix` and `airyaiprimex` are only defined for positive real inputs
+# `airybix` and `airybiprimex` are unscaled for negative real inputs
 @define_diffrule SpecialFunctions.airyai(x)      =
     :(  SpecialFunctions.airyaiprime($x)  )
 @define_diffrule SpecialFunctions.airyaiprime(x) =
     :(  $x * SpecialFunctions.airyai($x)  )
+@define_diffrule SpecialFunctions.airyaix(x)     =
+    :(  SpecialFunctions.airyaiprimex($x) + sqrt($x) * SpecialFunctions.airyaix($x)  )
+@define_diffrule SpecialFunctions.airyaiprimex(x) =
+    :(  $x * SpecialFunctions.airyaix($x) + sqrt($x) * SpecialFunctions.airyaiprimex($x)  )
 @define_diffrule SpecialFunctions.airybi(x)      =
     :(  SpecialFunctions.airybiprime($x)  )
 @define_diffrule SpecialFunctions.airybiprime(x) =
     :(  $x * SpecialFunctions.airybi($x)  )
+@define_diffrule SpecialFunctions.airybix(x)     =
+    :(  if $x > zero($x)
+            SpecialFunctions.airybiprimex($x) - sqrt($x) * SpecialFunctions.airybix($x)
+        else
+            SpecialFunctions.airybiprimex($x)
+        end  )
+@define_diffrule SpecialFunctions.airybiprimex(x) =
+    :(  if $x > zero($x)
+            $x * SpecialFunctions.airybix($x) - sqrt($x) * SpecialFunctions.airybiprimex($x)
+        else
+            $x * SpecialFunctions.airybix($x)
+        end  )
+
 @define_diffrule SpecialFunctions.besselj0(x)    =
     :( -SpecialFunctions.besselj1($x)  )
 @define_diffrule SpecialFunctions.besselj1(x)    =
@@ -149,49 +173,69 @@ _abs_deriv(x) = signbit(x) ? -one(x) : one(x)
 @define_diffrule SpecialFunctions.bessely1(x)    =
     :(  (SpecialFunctions.bessely0($x) - SpecialFunctions.bessely(2, $x)) / 2 )
 
+@define_diffrule SpecialFunctions.sinint(x) = :( sinc($x / π) )
+@define_diffrule SpecialFunctions.cosint(x) = :( cos($x) / $x )
+
+@define_diffrule SpecialFunctions.ellipk(m) =
+    :( (SpecialFunctions.ellipe($m) / (1 - $m) - SpecialFunctions.ellipk($m)) / (2 * $m) )
+@define_diffrule SpecialFunctions.ellipe(m) =
+    :( (SpecialFunctions.ellipe($m) - SpecialFunctions.ellipk($m)) / (2 * $m) )
+
 # TODO:
 #
 # eta
 # zeta
-# airyaix
-# airyaiprimex
-# airybix
-# airybiprimex
 
 # binary #
 #--------#
 
+# derivatives with respect to the order `ν` exist but are not implemented
+# (analogously to the ChainRules definitions in SpecialFunctions)
+
+# derivatives for `besselix`, `besseljx` and `besselyx` are only correct for real inputs
+# see https://github.com/JuliaMath/SpecialFunctions.jl/blob/master/src/chainrules.jl
+# for forward-mode and reverse-mode derivatives for complex inputs
+
 @define_diffrule SpecialFunctions.besselj(ν, x)   =
     :NaN, :(  (SpecialFunctions.besselj($ν - 1, $x) - SpecialFunctions.besselj($ν + 1, $x)) / 2  )
+@define_diffrule SpecialFunctions.besseljx(ν, x)  =
+    :NaN, :(  (SpecialFunctions.besseljx($ν - 1, $x) - SpecialFunctions.besseljx($ν + 1, $x)) / 2  )
 @define_diffrule SpecialFunctions.besseli(ν, x)   =
     :NaN, :(  (SpecialFunctions.besseli($ν - 1, $x) + SpecialFunctions.besseli($ν + 1, $x)) / 2  )
+@define_diffrule SpecialFunctions.besselix(ν, x)  =
+    :NaN, :(  (SpecialFunctions.besselix($ν - 1, $x) + SpecialFunctions.besselix($ν + 1, $x)) / 2 - sign($x) * SpecialFunctions.besselix($ν, $x)  )
 @define_diffrule SpecialFunctions.bessely(ν, x)   =
     :NaN, :(  (SpecialFunctions.bessely($ν - 1, $x) - SpecialFunctions.bessely($ν + 1, $x)) / 2  )
+@define_diffrule SpecialFunctions.besselyx(ν, x)  =
+    :NaN, :(  (SpecialFunctions.besselyx($ν - 1, $x) - SpecialFunctions.besselyx($ν + 1, $x)) / 2  )
 @define_diffrule SpecialFunctions.besselk(ν, x)   =
     :NaN, :( -(SpecialFunctions.besselk($ν - 1, $x) + SpecialFunctions.besselk($ν + 1, $x)) / 2  )
+@define_diffrule SpecialFunctions.besselkx(ν, x)  =
+    :NaN, :( -(SpecialFunctions.besselkx($ν - 1, $x) + SpecialFunctions.besselkx($ν + 1, $x)) / 2 + SpecialFunctions.besselkx($ν, $x)  )
+@define_diffrule SpecialFunctions.besselh(ν, x)   =
+    :NaN, :(  (SpecialFunctions.besselh($ν - 1, $x) - SpecialFunctions.besselh($ν + 1, $x)) / 2  )
+@define_diffrule SpecialFunctions.besselhx(ν, x) =
+    :NaN, :(  (SpecialFunctions.besselhx($ν - 1, $x) - SpecialFunctions.besselhx($ν + 1, $x)) / 2 - im * SpecialFunctions.besselhx($ν, $x)  )
 @define_diffrule SpecialFunctions.hankelh1(ν, x)  =
     :NaN, :(  (SpecialFunctions.hankelh1($ν - 1, $x) - SpecialFunctions.hankelh1($ν + 1, $x)) / 2  )
+@define_diffrule SpecialFunctions.hankelh1x(ν, x) =
+    :NaN, :(  (SpecialFunctions.hankelh1x($ν - 1, $x) - SpecialFunctions.hankelh1x($ν + 1, $x)) / 2 - im * SpecialFunctions.hankelh1x($ν, $x)  )
 @define_diffrule SpecialFunctions.hankelh2(ν, x)  =
     :NaN, :(  (SpecialFunctions.hankelh2($ν - 1, $x) - SpecialFunctions.hankelh2($ν + 1, $x)) / 2  )
+@define_diffrule SpecialFunctions.hankelh2x(ν, x) =
+    :NaN, :(  (SpecialFunctions.hankelh2x($ν - 1, $x) - SpecialFunctions.hankelh2x($ν + 1, $x)) / 2 + im * SpecialFunctions.hankelh2x($ν, $x)  )
+
 @define_diffrule SpecialFunctions.polygamma(m, x) =
     :NaN, :(  SpecialFunctions.polygamma($m + 1, $x)  )
+
 @define_diffrule SpecialFunctions.beta(a, b)      =
     :( SpecialFunctions.beta($a, $b)*(SpecialFunctions.digamma($a) - SpecialFunctions.digamma($a + $b)) ), :(  SpecialFunctions.beta($a, $b)*(SpecialFunctions.digamma($b) - SpecialFunctions.digamma($a + $b))     )
-@define_diffrule SpecialFunctions.logbeta(a, b)     =
+@define_diffrule SpecialFunctions.logbeta(a, b)   =
     :( SpecialFunctions.digamma($a) - SpecialFunctions.digamma($a + $b)  ), :(  SpecialFunctions.digamma($b) - SpecialFunctions.digamma($a + $b)  )
 
-# TODO:
-#
-# zeta
-# besseljx
-# besselyx
-# besselix
-# besselkx
-# besselh
-# besselhx
-# hankelh1x
-# hankelh2
-# hankelh2x
+# derivative wrt to `s` is not implemented
+@define_diffrule SpecialFunctions.zeta(s, z)      =
+    :NaN, :( - $s * SpecialFunctions.zeta($s + 1, $z)  )
 
 # ternary #
 #---------#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,14 +58,14 @@ for (M, f, arity) in DiffRules.diffrules(; filter_modules=nothing)
         end
         @eval begin
             let
-                if "mod" == string($M.$f)
-                    foo, bar = rand() + 13, rand() + 5 # make sure x/y is not integer
+                foo, bar = if "mod" == string($M.$f)
+                    rand() + 13, rand() + 5 # make sure x/y is not integer
                 else
-                    foo, bar = rand(1.0:10.0), rand()
+                    rand(1:10), rand()
                 end
                 dx, dy = $(derivs[1]), $(derivs[2])
                 if !isnan(dx)
-                    @test dx ≈ $fd(z -> $M.$f(z, bar), foo) rtol=1e-9 atol=1e-9
+                    @test dx ≈ $fd(z -> $M.$f(z, bar), float(foo)) rtol=1e-9 atol=1e-9
                 end
                 if !isnan(dy)
                     @test dy ≈ $fd(z -> $M.$f(foo, z), bar) rtol=1e-9 atol=1e-9

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,12 +18,16 @@ for (M, f, arity) in DiffRules.diffrules(; filter_modules=nothing)
     if arity == 1
         @test DiffRules.hasdiffrule(M, f, 1)
         deriv = DiffRules.diffrule(M, f, :goo)
-        modifier = if f in (:asec, :acsc, :asecd, :acscd, :acosh, :acoth)
+        modifier = if f in (:asec, :acsc, :asecd, :acscd, :acosh)
             1.0
+        elseif f === :acoth
+            1.1 # values too close to 1 are problematic for finite differencing
         elseif f === :log1mexp
             -1.0
         elseif f === :log2mexp
             -0.5
+        elseif f in (:airyaix, :airyaiprimex)
+            0.1 # values too close to 0 are problematic for finite differencing
         else
             0.0
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,16 +30,16 @@ for (M, f, arity) in DiffRules.diffrules(; filter_modules=nothing)
         else
             0.0
         end
+        fd = if f in (:acoth, :log, :airyaix, :airyaiprimex)
+            # avoid singularities
+            finitediff_forward
+        else
+            finitediff
+        end
         @eval begin
             let
                 goo = rand() + $modifier
-                fd_deriv = if f in (:acoth, :log, :airyaix, :airyaiprimex)
-                    # avoid singularities
-                    finitediff_forward($M.$f, goo)
-                else
-                    finitediff($M.$f, goo)
-                end
-                @test $deriv ≈ fd_deriv rtol=1e-9 atol=1e-9
+                @test $deriv ≈ $fd($M.$f, goo) rtol=1e-9 atol=1e-9
                 # test for 2pi functions
                 if "mod2pi" == string($M.$f)
                     goo = 4pi + $modifier

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using DiffRules
-using FiniteDifferences
 using Test
 using FiniteDifferences
 


### PR DESCRIPTION
This PR is both an alternative and an extension of https://github.com/JuliaDiff/DiffRules.jl/pull/66.

It adds missing rules for functions defined in SpecialFunctions >= 0.10: https://specialfunctions.juliamath.org/v0.10/functions_list

Hence in contrast to #66 it does not add a rule for the incomplete gamma function which is only available in SpecialFunctions >= 1.2 and also does not require to update the SpecialFunctions compat entry.

I went through the list of functions in SpecialFunctions 0.10 and added rules that were missing for functions that are differentiable with respect to at least one argument and return scalar values (some functions return tuples but AFAIK these are not supported by DiffRules). Some functions are not holomorphic (e.g. `besselix`) and hence derivatives are only correct for real-valued inputs. It seems DiffRules does not support non-holomorphic functions and hence I only copied the rules for real inputs but not the ones for complex inputs from e.g. https://github.com/JuliaMath/SpecialFunctions.jl/blob/1febdd05902f5b3a3adc9915aba40b776aa3ea24/src/chainrules.jl#L198-L223; I also added some explanations to the code.

To make sure that the rules are defined correctly I added FiniteDifferences as a test dependency and decreased relative and absolute tolerances to 1e-9 (not possible with the current basic finite differencing algorithm).