### PR TITLE
Use FiniteDifferences in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,9 @@ SpecialFunctions = "0.10, 1.0, 2"
 julia = "1.3"
 
 [extras]
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["FiniteDifferences", "Test", "Random"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,9 +56,12 @@ for (M, f, arity) in DiffRules.diffrules(; filter_modules=nothing)
                 elseif $(f === :log)
                     # avoid singularities with finite differencing
                     rand() + 1.5, rand()
-                elseif $(f === :^)
+                elseif $(f in (:^, :pow))
                     # avoid singularities with finite differencing
                     rand() + 0.5, rand()
+                elseif $(f === :logbeta)
+                    # avoid singularities with finite differencing
+                    rand() + 0.5, rand() + 0.5
                 else
                     rand(), rand()
                 end


### PR DESCRIPTION
I extracted this PR from https://github.com/JuliaDiff/DiffRules.jl/pull/79, I guess this makes it easier to review.

This PR replaces the custom and very basic forward finite differencing method in the tests with FiniteDifferences (e.g. also used by ChainRulesTestUtils). This allows us to lower the tolerances quite significantly which hopefully uncovers incorrect implementations more reliably.