### PR TITLE
Add diffrules for `log1pmx` and `logmxp1`

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -244,6 +244,8 @@ _abs_deriv(x) = signbit(x) ? -one(x) : one(x)
 @define_diffrule LogExpFunctions.log1mexp(x) = :(-exp($x - LogExpFunctions.log1mexp($x)))
 @define_diffrule LogExpFunctions.log2mexp(x) = :(-exp($x - LogExpFunctions.log2mexp($x)))
 @define_diffrule LogExpFunctions.logexpm1(x) = :(exp($x - LogExpFunctions.logexpm1($x)))
+@define_diffrule LogExpFunctions.log1pmx(x) = :(-$x / (1 + $x))
+@define_diffrule LogExpFunctions.logmxp1(x) = :(inv($x) - 1)
 
 # binary
 @define_diffrule LogExpFunctions.xlogy(x, y) = :(log($y)), :($x / $y)


### PR DESCRIPTION
There may be more optimal orders of operations for these derivatives.
Also, could someone assist me in what would be mandatory tests for these additions?