### PR TITLE
Use strong zeros in the diffrules for min/max

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffRules"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.12.0"
+version = "1.12.1"
 
 [deps]
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -90,8 +90,8 @@ _abs_deriv(x) = signbit(x) ? -one(x) : one(x)
 @define_diffrule Base.mod(x, y)    = :( z = $x / $y; ifelse(isinteger(z), oftype(float(z), NaN), one(float(z))) ), :(  z = $x / $y; ifelse(isinteger(z), oftype(float(z), NaN), -floor(float(z))) )
 @define_diffrule Base.rem(x, y)    = :( z = $x / $y; ifelse(isinteger(z), oftype(float(z), NaN), one(float(z))) ), :(  z = $x / $y; ifelse(isinteger(z), oftype(float(z), NaN), -trunc(float(z))) )
 @define_diffrule Base.rem2pi(x, r) = :( 1                                                       ), :NaN
-@define_diffrule Base.max(x, y)    = :( $x > $y ? one($x) : zero($x)                            ), :( $x > $y ? zero($y) : one($y)                                            )
-@define_diffrule Base.min(x, y)    = :( $x > $y ? zero($x) : one($x)                            ), :( $x > $y ? one($y) : zero($y)                                            )
+@define_diffrule Base.max(x, y)    = :( $x > $y ), :( !($x > $y) )
+@define_diffrule Base.min(x, y)    = :( !($x > $y) ), :( $x > $y )
 
 # trinary #
 #---------#


### PR DESCRIPTION
Fixes https://github.com/JuliaDiff/ForwardDiff.jl/issues/603 and makes the definitions here consistent with ChainRules (https://github.com/JuliaDiff/ChainRules.jl/blob/5818173b31fac9d358acda21f5751978a5dcb2e5/src/rulesets/Base/fastmath_able.jl#L220).