### PR TITLE
Support IrrationalConstants 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffRules"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.12.2"
+version = "1.13.0"
 
 [deps]
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
@@ -10,7 +10,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-IrrationalConstants = "0.1.1"
+IrrationalConstants = "0.1.1, 0.2"
 LogExpFunctions = "0.3.2"
 NaNMath = "0.3, 1"
 SpecialFunctions = "0.10, 1.0, 2"


### PR DESCRIPTION
IrrationalConstants 0.2 changes the type of the irrational constants to fix a type piracy issue: https://github.com/JuliaMath/IrrationalConstants.jl/pull/19 This change is breaking but should not cause any problems in DiffRules.