### PR TITLE
Remove EAGO from downstream CI testing

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -30,7 +30,6 @@ jobs:
           - {user: FluxML, repo: Zygote.jl, group: All}
           - {user: JuliaSymbolics, repo: Symbolics.jl, group: All}
           - {user: SciML, repo: ModelingToolkit.jl, group: All}
-          - {user: PSORLab, repo: EAGO.jl, group: All}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The package has had failing CI on releases for quite some time.