### PR TITLE
Update abs diff rule to 0 at non-differentiable point

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -70,7 +70,7 @@
 
 # We provide this hook for special number types like `Interval`
 # that need their own special definition of `abs`.
-_abs_deriv(x) = signbit(x) ? -one(x) : one(x)
+_abs_deriv(x) = sign(x)
 
 # binary #
 #--------#


### PR DESCRIPTION
This PR updates the diffrule for `abs` to return 0 at the non-differentiable point. The current implementation returns 1. Although valid, this can prevent convergence in gradient descent. The implementation in this PR is the behavior the  [ChainRules.jl docs](https://juliadiff.org/ChainRulesCore.jl/dev/maths/nondiff_points.html) advises. 

This also comes with the added benefit of not requiring the type to support the ternary operator such as `IntervalArithmetic.Interval`. This is the use case that led me to make this PR.

```julia
using IntervalArithmetic, ForwardDiff

ForwardDiff.derivative(abs, -2.0 .. 2.0)
```

```julia
ERROR: TypeError: non-boolean (Interval{Float64}) used in boolean context
Stacktrace:
 [1] _abs_deriv(x::Interval{Float64})
   @ DiffRules ~/.julia/packages/DiffRules/wKSai/src/rules.jl:73
 [2] abs
   @ ~/.julia/packages/ForwardDiff/vXysl/src/dual.jl:240 [inlined]
```

With this PR:

```
ForwardDiff.derivative(abs, -2.0 .. 2.0) # [-1, 1]
ForwardDiff.derivative(abs, 0.0 .. 2.0)  # [0, 1]
ForwardDiff.derivative(abs, -3.0 .. 1.0) # [ -1, -1]
```

The diffrule for `abs` has the following comment, which I'm not sure how to interpret. As it doesn't work with `IntervalArithmetic.Interval` or `Intervals.Intervel`. Additionally, the current definition assumes that 0 is not in the interval. 

https://github.com/JuliaDiff/DiffRules.jl/blob/2001650a4a009d2136f89496f2d22fe7fb04dfbd/src/rules.jl#L71
