### PR TITLE
Revert "Update abs diff rule to 0 at non-differentiable point"

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -70,7 +70,7 @@
 
 # We provide this hook for special number types like `Interval`
 # that need their own special definition of `abs`.
-_abs_deriv(x) = sign(x)
+_abs_deriv(x) = signbit(x) ? -one(x) : one(x)
 
 # binary #
 #--------#


### PR DESCRIPTION
Reverts JuliaDiff/DiffRules.jl#98, due to the problem explained in https://github.com/JuliaDiff/DiffRules.jl/pull/98#issuecomment-1574420052.

Maybe this issue explains why the "derivative" at 0 was defined as 1 originally (first in ForwardDiff, and then in DiffRules when thw rule was moved here) - but unfortunately neither DiffRules nor ForwardDiff tests it.

In principle, it seems that one could argue for any subderivative, ie., any number in [-1, 1], as the "derivative" at 0. The `abs` function is also discussed in the ChainRules docs, where it is arfued for taking the subderivative 0 and against -1 or 1. However, yhe example in https://github.com/JuliaDiff/DiffRules.jl/pull/98#issuecomment-1574420052 provides an argument for taking 1.