### PR TITLE
Replace latest badge with dev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/JuliaDiff/DiffRules.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaDiff/DiffRules.jl?branch=master)
 
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadiff.org/DiffRules.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliadiff.org/DiffRules.jl/latest)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliadiff.org/DiffRules.jl/dev)
 
 Many differentiation methods rely on the notion of "primitive" differentiation rules that
 can be composed via various formulations of the chain rule. Using DiffRules, you can define


### PR DESCRIPTION
https://juliadiff.org/DiffRules.jl/latest is not up-to-date. This PR replaces the link with https://juliadiff.org/DiffRules.jl/dev.